### PR TITLE
Fix: handle string_type locally

### DIFF
--- a/snippet/plugin.py
+++ b/snippet/plugin.py
@@ -7,12 +7,19 @@ import shutil
 import re
 import os
 import mkdocs
+import sys
 
 
 class SnippetPlugin(BasePlugin):
+
+    if sys.version_info[0] == 3:
+        string_types = str
+    else:
+        string_types = basestring
+
     config_scheme = (('base_path',
                       mkdocs.config.config_options.Type(
-                          mkdocs.utils.string_types, default=None)), )
+                          string_types, default=None)), )
 
     page = None
 


### PR DESCRIPTION
mkdocs removed support for python2.7 which included the string_types call it provided. This handles the difference locally.

fixes: #2 